### PR TITLE
threads.xs: Rmv impediment to compiling under C++11

### DIFF
--- a/threads.xs
+++ b/threads.xs
@@ -1491,7 +1491,9 @@ ithread_kill(...)
         MUTEX_UNLOCK(&thread->mutex);
 
         if (no_handler) {
-            Perl_croak(aTHX_ "Signal %s received in thread %"UVuf", but no signal handler set.", sig_name, thread->tid);
+            Perl_croak(aTHX_ "Signal %s received in thread %" UVuf
+                             ", but no signal handler set.",
+                             sig_name, thread->tid);
         }
 
         /* Return the thread to allow for method chaining */


### PR DESCRIPTION
C++11 changed from earlier versions to require space between the end of
a string literal and a macro, so that a feature can unambiguously be
added to the language.  Starting in g++ 6.2, the compiler emits a
deprecation warning when there isn't a space (presumably so that future
versions can support C++11).

This patch also changes the affected line to not exceed 79 columns, as
specified by perlhack.

Code and modules included with the Perl core need to be compilable using
C++.  This is so that perl can be embedded in C++ programs. (Actually,
only the hdr files need to be so compilable, but it would be hard to
test that just the hdrs are compilable.)  So we need to accommodate
changes to the C++ language.